### PR TITLE
Fetch and process counties concurrently

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!-- 
+  This template is meant to be a guide; don't feel like you need to fill out everything here.  
+  Delete sections or checklist items if they are not relevant to your PR to make it easier to read/review! 
+-->
+
+## What's this PR do?
+<!-- Succinctly state the changes you are making (for example: "Reduced number of articles on the homepage by one.") -->
+- 
+
+<!-- before/after table when relevant -->
+<!-- | Before | After |
+| ----- | ----- |
+| image1 |  image2 |  -->
+
+
+## Why are we doing this? How does it help us?
+<!-- Describe the reasons for these changes -->
+- 
+
+## Are there any smells or added technical debt to note?
+
+## TODOs / next steps:
+<!-- Remove any checklist items that don't apply to your PR. -->
+<!-- Examples:  "Run django migration," "Slack notify #all-general," etc. -->
+* [ ] *your TODO here*

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "form-data": "^4.0.0",
         "joi": "^17.8.3",
         "lodash": "^4.17.21",
-        "node-html-parser": "^6.1.5",
-        "pdf-parse": "^1.1.1"
+        "node-html-parser": "^6.1.5"
       }
     },
     "node_modules/@adobe/node-fetch-retry": {
@@ -141,14 +140,6 @@
       "version": "1.11.7",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
       "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
-    },
-    "node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -293,16 +284,6 @@
         "node": "*"
       }
     },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/node-ensure": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
-      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw=="
-    },
     "node_modules/node-fetch": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
@@ -340,18 +321,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/pdf-parse": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
-      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
-      "dependencies": {
-        "debug": "^3.1.0",
-        "node-ensure": "^0.0.0"
-      },
-      "engines": {
-        "node": ">=6.8.1"
       }
     },
     "node_modules/tr46": {
@@ -481,14 +450,6 @@
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
       "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
     },
-    "debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "requires": {
-        "ms": "^2.1.1"
-      }
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -587,16 +548,6 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
-    "ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node-ensure": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
-      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw=="
-    },
     "node-fetch": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
@@ -620,15 +571,6 @@
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "requires": {
         "boolbase": "^1.0.0"
-      }
-    },
-    "pdf-parse": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
-      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
-      "requires": {
-        "debug": "^3.1.0",
-        "node-ensure": "^0.0.0"
       }
     },
     "tr46": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aopc-simple-scraper",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aopc-simple-scraper",
-      "version": "1.0.0",
+      "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
         "@adobe/node-fetch-retry": "^2.2.0",
@@ -16,7 +16,8 @@
         "form-data": "^4.0.0",
         "joi": "^17.8.3",
         "lodash": "^4.17.21",
-        "node-html-parser": "^6.1.5"
+        "node-html-parser": "^6.1.5",
+        "pdf-parse": "^1.1.1"
       }
     },
     "node_modules/@adobe/node-fetch-retry": {
@@ -134,6 +135,14 @@
       "version": "1.11.7",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
       "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
+    },
+    "node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -278,6 +287,16 @@
         "node": "*"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw=="
+    },
     "node_modules/node-fetch": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
@@ -315,6 +334,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
       }
     },
     "node_modules/tr46": {
@@ -439,6 +470,14 @@
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
       "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
     },
+    "debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -537,6 +576,16 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw=="
+    },
     "node-fetch": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
@@ -560,6 +609,15 @@
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "requires": {
         "boolbase": "^1.0.0"
+      }
+    },
+    "pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "requires": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
       }
     },
     "tr46": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@adobe/node-fetch-retry": "^2.2.0",
         "@hapi/bourne": "^3.0.0",
         "@joi/date": "^2.1.0",
+        "async": "^3.2.4",
         "dayjs": "^1.11.7",
         "form-data": "^4.0.0",
         "joi": "^17.8.3",
@@ -83,6 +84,11 @@
       "engines": {
         "node": ">=6.5"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -429,6 +435,11 @@
       "requires": {
         "event-target-shim": "^5.0.0"
       }
+    },
+    "async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "asynckit": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "form-data": "^4.0.0",
     "joi": "^17.8.3",
     "lodash": "^4.17.21",
-    "node-html-parser": "^6.1.5"
+    "node-html-parser": "^6.1.5",
+    "pdf-parse": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@adobe/node-fetch-retry": "^2.2.0",
     "@hapi/bourne": "^3.0.0",
     "@joi/date": "^2.1.0",
+    "async": "^3.2.4",
     "dayjs": "^1.11.7",
     "form-data": "^4.0.0",
     "joi": "^17.8.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aopc-simple-scraper",
   "version": "0.1.0",
-  "description": "",
+  "description": "Pennsylvania district court case scraper",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aopc-simple-scraper",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "form-data": "^4.0.0",
     "joi": "^17.8.3",
     "lodash": "^4.17.21",
-    "node-html-parser": "^6.1.5",
-    "pdf-parse": "^1.1.1"
+    "node-html-parser": "^6.1.5"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,16 @@ const scrape = require("./scrape");
 const { schemaFileDts } = require("./utils/validation");
 const { arrayToCsv } = require("./utils/misc");
 
+
+/**
+ * Scrape criminal case docket data from website of the Administrative Office of Pennsylvania Courts and
+ * save to JSON and CSV files.
+ * @param {String} options.filedStartDate Start date of data to scrape in format 'YYYY-MM-DD'. Defaults to yesterday, New York.
+ * @param {String} options.filedEndDate End date of data to scrape in format 'YYYY-MM-DD'. Defaults to filedStartDate
+ * @param {Array, String} options.counties List of counties to get data for. Use "*" for all counties. Defaults to "*"
+ * @param {Array, String} options.outputPath Where to save the file. Defaults to "./"
+ * @returns undefined
+ */
 const scrapeAndSave = async (
     {
         filedStartDate,
@@ -18,15 +28,6 @@ const scrapeAndSave = async (
         outputPath = "."
     } = {}
 ) => {
-    /**
-     * Scrape criminal case docket data from website of the Administrative Office of Pennsylvania Courts and
-     * save to JSON and CSV files.
-     * @param {String} options.filedStartDate Start date of data to scrape in format 'YYYY-MM-DD'. Defaults to yesterday, New York.
-     * @param {String} options.filedEndDate End date of data to scrape in format 'YYYY-MM-DD'. Defaults to filedStartDate
-     * @param {Array, String} options.counties List of counties to get data for. Use "*" for all counties. Defaults to "*"
-     * @param {Array, String} options.outputPath Where to save the file. Defaults to "./"
-     * @returns undefined
-     */
     // start
     const startTime = dayjs().tz("America/New_York");
     console.log("Scrape begin:", startTime.format("ddd, MMM D, YYYY h:mm A"));

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,7 @@ const scrapeAndSave = async (
     // analyze
     const endTime = dayjs().tz("America/New_York");
     console.log("Scrape end:", endTime.format("ddd, MMM D, YYYY h:mm A"));
+    console.log("Total crim dockets found:", dockets.length);
     const scrapeDurationSec = endTime.diff(startTime, "seconds");
     const scrapeDurationFmt = `${scrapeDurationSec} seconds`;
     console.log(`Scrape duration: ${scrapeDurationFmt}`);

--- a/src/scrape.js
+++ b/src/scrape.js
@@ -114,7 +114,7 @@ const scrape = (
   });
 
   countyQueue.drain(() => {
-    console.log(`All ${counties.length} succesfully processed`);
+    console.log(`All ${counties.length} successfully processed`);
     resolve(docketData);
   })
 });

--- a/src/scrape.js
+++ b/src/scrape.js
@@ -23,7 +23,18 @@ const { schemaFileDts } = require("./utils/validation");
 const docketData = [];
 
 
-const scrapeCounty = async ({ county, cookies, token, filedStartDate, filedEndDate }) => {
+/**
+ * Fetch and parse criminal case dockets for a single county from the website of the
+ * Administrative Office of Pennsylvania Courts. Payload is added to docketData array.
+ * 
+ * @param {String} args.county County to get data for
+ * @param {String} args.cookies Cookies to use for request
+ * @param {String} args.token Token to use for request
+ * @param {String} args.filedStartDate Start date of data to scrape in format 'YYYY-MM-DD'.
+ * @param {String} args.filedEndDate End date of data to scrape in format 'YYYY-MM-DD'.
+ * @returns {undefined} 
+ */
+const scrapeCounty = async ({ county, cookies, token, filedStartDate, filedEndDate } = {}) => {
   console.log(`Getting docket data for ${county}...`);
   const form = buildFormData(token, county, filedStartDate, filedEndDate);
   const resCases = await fetch("https://ujsportal.pacourts.us/CaseSearch", {

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -35,16 +35,16 @@ const parseTokenFromDom = (dom) => {
   return elInput.getAttribute("value");
 };
 
-const parseDocketsFromHtml = (html) => {
+const parseDocketsFromHtml = (county, html) => {
   const docketsDom = parse(html);
   const docketsTable = docketsDom.querySelector("div.table-wrapper tbody");
   if (!docketsTable) {
-    throw new ScrapeError(`Expected to extract table element but instead extracted ${docketsTable}. Check the provided HTML`)
+    throw new ScrapeError(`${county}: Expected to extract table element but instead extracted ${docketsTable}. Check the provided HTML`)
   }
   const rows = docketsTable.querySelectorAll("tr");
   const docketData = [];
   const reCrimDockets = /[A-Z]{2}-\d{4,6}-CR-\d{4,8}-\d{4}/;
-  console.log(`Total rows on page: ${rows.length}`);
+  console.log(`${county}: Total rows on page: ${rows.length}`);
   rows.forEach((cell) => {
     const docketId = cell.querySelectorAll("td")[2].textContent;
     const court = cell.querySelectorAll("td")[3].textContent;
@@ -68,16 +68,16 @@ const parseDocketsFromHtml = (html) => {
       });
     }
   });
-  console.log(`Found ${docketData.length} crim dockets`);
+  console.log(`${county}: Found ${docketData.length} crim dockets`);
   const uniqueDocketItems = _.uniqBy(docketData, function (e) {
     return e.docketId;
   });
   const diff = docketData.length - uniqueDocketItems.length;
   if (diff > 0) {
     console.log(
-      `Note: ${diff} crim dockets have duplicate docketIds – removing`
+      `${county}: Note – ${diff} crim dockets have duplicate docketIds – removing`
     );
-    console.log(`Returning ${uniqueDocketItems.length} crim dockets`);
+    console.log(`${county}: Returning ${uniqueDocketItems.length} crim dockets`);
   }
   return uniqueDocketItems;
 };


### PR DESCRIPTION
## What's this PR do?
Adds a queue so that the app can fetch and process county dockets concurrently.

## Why are we doing this? How does it help us?
The app can now scrape and process all 67 counties significantly faster.

## Are there any smells or added technical debt to note?
If you set `threadCount` too high you risk being rate limited by AOPC's servers. I've set the default threadCount to five. It seems to be a safe number.

## TODOs / next steps:
<!-- Remove any checklist items that don't apply to your PR. -->
<!-- Examples:  "Run django migration," "Slack notify #all-general," etc. -->
* [ ] *your TODO here*
